### PR TITLE
fix(packageRules): Consolidate packageRules

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,10 @@
           "packagePatterns": [
             "*"
           ],
-          "enabled": false
-        },
-        {
-          "packagePatterns": [
+          "excludePackagePatterns": [
             "(^(@)?seek.*)|(.*-seek$)|(^sku.*)|(.*-sku$)"
           ],
-          "enabled": true
+          "enabled": false
         }
       ]
     }


### PR DESCRIPTION
Consolidates existing two packageRules into one. It's also a bit "safer" because the logic for which patterns to match are combined into one rule. Otherwise, what happens before this change is that all packages would match the first rule and be disabled, but then some would match the second rule and be re-enabled. With the new approach, packages are only matched once. Both ways work, but I think this is easier to understand and maintain.