### PR TITLE
feat(default): Only pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
           ],
           "enabled": false
         }
-      ]
+      ],
+      "pinVersions": false,
+      "dependencies": {
+        "pinVersions": true
+      }
     }
   },
   "config": {


### PR DESCRIPTION
Currently the renovate default is `pinVersions: true`, which requires all packages that renovate looks after use exact versions and PRs will be opened for every patch release of a dependency. There is also [some inference](https://renovateapp.com/docs/configuration-reference/configuration-options#pinversions) around how this is set based on repo.

I propose we standardise this and only pin `dependencies` allowing ranges to be used for `devDependencies`, eg. `eslint-config-seek`. This means we will only get PRs generated for production `dependencies` or `devDependencies` outside of semver range.