### PR TITLE
fix(default): Match any package name with “-seek-”

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
             "*"
           ],
           "excludePackagePatterns": [
-            "(^(@)?seek.*)|(.*-seek$)|(^sku.*)|(.*-sku$)"
+            "(^(@)?seek.*)|(.*-seek(-.*|$))|(^sku.*)|(.*-sku$)"
           ],
           "enabled": false
         }
@@ -60,7 +60,7 @@
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
-    "renovate": "10.49.3",
+    "renovate": "^11.34.2",
     "semantic-release": "^11.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -4,9 +4,39 @@ const pkgJson = require('./package.json');
 
 const config = pkgJson['renovate-config'];
 
+// Validate the config with Renovate
+
 Object.keys(config).forEach(presetName => {
   const { errors, warnings } = validateConfig(config[presetName]);
-
   assert(errors.length === 0, `Preset '${presetName}' contains errors:\n\n${JSON.stringify(errors, null, 2)}`);
   assert(warnings.length === 0, `Preset '${presetName}' contains warnings:\n\n${JSON.stringify(warnings, null, 2)}`);
+});
+
+// Test that we correctly match SEEK packages
+
+const seekPackageRegex = new RegExp(pkgJson['renovate-config'].default.packageRules[0].excludePackagePatterns[0]);
+
+const exampleSeekPackages = [
+  'sku',
+  'eslint-config-sku',
+  'seek-style-guide',
+  'eslint-config-seek',
+  'babel-plugin-seek-style-guide',
+  '@seek/private-package'
+];
+
+exampleSeekPackages.forEach(exampleSeekPackage => {
+  assert(seekPackageRegex.test(exampleSeekPackage), `${exampleSeekPackage} should match`);
+});
+
+// Test that we correctly ignore non-SEEK packages
+
+const exampleNonSeekPackages = [
+  'react',
+  'webpack',
+  'jest'
+];
+
+exampleNonSeekPackages.forEach(exampleNonSeekPackage => {
+  assert(!seekPackageRegex.test(exampleNonSeekPackage), `${exampleNonSeekPackage} should *not* match`);
 });


### PR DESCRIPTION
This was added specifically to target [babel-plugin-seek-style-guide](https://github.com/seek-oss/babel-plugin-seek-style-guide), but in a manner that will support future packages that have similar naming conventions.

Also, since I was changing the regular expression, it felt like a good idea to write some simple tests to ensure it's working as expected.