### PR TITLE
fix(default): Ignore project npmrc to avoid service clash

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "config:base"
       ],
       "branchPrefix": "renovate--",
+      "ignoreNpmrcFile": true,
       "lockFileMaintenance": {
         "enabled": false
       },


### PR DESCRIPTION
Having recently introduced an `.npmrc` file to a project we found the Renovate service was no longer providing PRs. Turns out this project level npm config was overriding the one created by Renovate to authenticate and access private node modules.

This is the recommendation from the author:

>Adding `"ignoreNpmrcFile": true` to your preset will have the effect of telling Renovate to not look for any .npmrc file in any of your repositories that use the preset.

Given the repo access from our perspective is to retrieve the `package.json` file and the release notes this seems like a fair thing to disable.