### PR TITLE
test(validator): Use new validator

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,19 +1,10 @@
 const assert = require('assert');
-const { validateConfig } = require('renovate/lib/config/validation');
 const pkgJson = require('./package.json');
 
-const config = pkgJson['renovate-config'];
-
 // Validate the config with Renovate
-
-Object.keys(config).forEach(presetName => {
-  const { errors, warnings } = validateConfig(config[presetName]);
-  assert(errors.length === 0, `Preset '${presetName}' contains errors:\n\n${JSON.stringify(errors, null, 2)}`);
-  assert(warnings.length === 0, `Preset '${presetName}' contains warnings:\n\n${JSON.stringify(warnings, null, 2)}`);
-});
+require('renovate/bin/config-validator');
 
 // Test that we correctly match SEEK packages
-
 const seekPackageRegex = new RegExp(pkgJson['renovate-config'].default.packageRules[0].excludePackagePatterns[0]);
 
 const exampleSeekPackages = [
@@ -30,7 +21,6 @@ exampleSeekPackages.forEach(exampleSeekPackage => {
 });
 
 // Test that we correctly ignore non-SEEK packages
-
 const exampleNonSeekPackages = [
   'react',
   'webpack',


### PR DESCRIPTION
Now using the updated [validator](https://github.com/renovateapp/renovate/blob/master/bin/config-validator.js) to validate all forms of renovate configuration. The validator now formats errors better and errors on warnings like our implementation too.

This unblocks the pipeline.