### PR TITLE
feat(default): Adopt new rangeStrategy and commitMessage formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,13 @@
           "depTypeList": [
             "dependencies"
           ],
-          "rangeStrategy": "pin"
+          "rangeStrategy": "auto"
+        },
+        {
+          "depTypeList": [
+            "devDependencies"
+          ],
+          "rangeStrategy": "replace"
         },
         {
           "depTypeList": [

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
         "enabled": false
       },
       "semanticCommits": false,
-      "prTitle": "{{semanticCommitType}}({{semanticCommitScope}}): {{#if isPin}}Pin{{else}}{{#if isRollback}}Roll back{{else}}Update{{/if}}{{/if}} {{depName}} to {{#unless isRange}}v{{/unless}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}",
-      "commitMessage": "{{semanticCommitType}}({{semanticCommitScope}}): Update {{depName}} to {{#unless isRange}}v{{/unless}}{{newVersion}}",
+      "commitMessagePrefix": "{{semanticCommitType}}({{semanticCommitScope}})",
+      "commitMessageAction": "{{#if isPin}}Pin{{else}}{{#if isRollback}}Roll back{{else}}Update{{/if}}{{/if}}",
+      "commitMessageExtra": "to {{#unless isRange}}v{{/unless}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}",
       "packageRules": [
         {
           "packagePatterns": [
@@ -42,12 +43,20 @@
             "(^(@)?seek.*)|(.*-seek(-.*|$))|(^sku.*)|(.*-sku$)"
           ],
           "enabled": false
+        },
+        {
+          "depTypeList": [
+            "dependencies"
+          ],
+          "rangeStrategy": "pin"
+        },
+        {
+          "depTypeList": [
+            "peerDependencies"
+          ],
+          "rangeStrategy": "widen"
         }
-      ],
-      "pinVersions": false,
-      "dependencies": {
-        "pinVersions": true
-      }
+      ]
     }
   },
   "config": {
@@ -61,7 +70,7 @@
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
-    "renovate": "^11.34.2",
+    "renovate": "^12.56.15",
     "semantic-release": "^11.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "enabled": false
       },
       "semanticCommits": false,
-      "commitMessagePrefix": "{{semanticCommitType}}({{semanticCommitScope}})",
+      "commitMessagePrefix": "{{semanticCommitType}}({{semanticCommitScope}}):",
       "commitMessageAction": "{{#if isPin}}Pin{{else}}{{#if isRollback}}Roll back{{else}}Update{{/if}}{{/if}}",
       "commitMessageExtra": "to {{#unless isRange}}v{{/unless}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}",
       "packageRules": [


### PR DESCRIPTION
The newer versions of Renovate have made some config changes that we should migrate to:

- `pinVersions` to [`rangeStrategy`](https://renovatebot.com/docs/configuration-options/#rangestrategy)
This is much more powerful and I have configured it to continue to work as expected for now while also adding in a `peerDependency` opinion based on observed practices

- `prTitle` [is deprecated](https://renovatebot.com/docs/configuration-options/#prtitle)
Now uses `commitMessage`.

- Break up `commitMessage` [into parts](https://renovatebot.com/docs/configuration-options/#commitmessage)
Now configuring the individual parts that build the message, this is also used for PR titles so its a good clean up.

I have trialled all this on a separate repo and am happy with the results. Happy to discuss with anyone curious.