### PR TITLE
feat: Add support for braid-design-system packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
             "*"
           ],
           "excludePackagePatterns": [
-            "(^(@)?seek.*)|(.*-seek(-.*|$))|(^sku.*)|(.*-sku$)"
+            "(^((@)?seek|sku|braid-design-system).*)|(.*-(seek|sku|braid-design-system)(-.*|$))"
           ],
           "enabled": false
         },
@@ -79,7 +79,7 @@
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
-    "renovate": "^12.56.15",
+    "renovate": "^13.88.1",
     "semantic-release": "^15.5.5"
   }
 }

--- a/test.js
+++ b/test.js
@@ -13,7 +13,10 @@ const exampleSeekPackages = [
   'seek-style-guide',
   'eslint-config-seek',
   'babel-plugin-seek-style-guide',
-  '@seek/private-package'
+  '@seek/private-package',
+  'braid-design-system',
+  'braid-design-system-webpack',
+  'babel-plugin-braid-design-system'
 ];
 
 exampleSeekPackages.forEach(exampleSeekPackage => {
@@ -24,7 +27,8 @@ exampleSeekPackages.forEach(exampleSeekPackage => {
 const exampleNonSeekPackages = [
   'react',
   'webpack',
-  'jest'
+  'jest',
+  'braid' // We want to own 'braid-design-system', not 'braid'
 ];
 
 exampleNonSeekPackages.forEach(exampleNonSeekPackage => {


### PR DESCRIPTION
## Description

Any package with `braid-design-system` in the name will now be updated by Renovate.

## Development Notes

I've also simplified the regular expression to match `seek` / `sku` / `braid-design-system` in a consistent way, where they need to be at the start, the end (prefixed with a hyphen), or surrounded by hyphens. The only exception to this is that `seek` is allowed to be prefixed with an `@`, since it's also an org.

I also updated the `renovate` package while I was at it, to make sure our config is still valid with the latest version of Renovate.