### PR TITLE
feat(default): Enable support for buildkite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "renovate-config": {
     "default": {
       "extends": [
-        "config:base"
+        "config:base",
+        "preview:buildkite"
       ],
       "branchPrefix": "renovate--",
       "ignoreNpmrcFile": true,


### PR DESCRIPTION
Renovate now supports managing buildkite plugins. 

To do so there is a preset you can enable: https://renovatebot.com/docs/presets-preview/#previewbuildkite.