### PR TITLE
fix: Formalise branch prefix as `renovate-`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "extends": [
         "config:base"
       ],
-      "branchPrefix": "renovate--",
+      "branchPrefix": "renovate-",
       "ignoreNpmrcFile": true,
       "lockFileMaintenance": {
         "enabled": false


### PR DESCRIPTION
`renovate--` appears to be normalised to `renovate-` by Renovate now. This formalises the change so we aren't beholden to Renovate's implementation details which could flip back to respecting `renovate--` in future.